### PR TITLE
Send metrics to a measurement and align times

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@ go-metrics-influxdb
 
 This is a reporter for the [go-metrics](https://github.com/rcrowley/go-metrics) library which will post the metrics to [InfluxDB](https://influxdb.com/).
 
+This version adds a measurement for the metrics, moves the histogram bucket names into tags, similar to the behavior of hitograms in telegraf, and aligns all metrics in a batch on the same timestamp.
+
+Additionally, metrics can be aligned to the beginning of a bucket as defined by the interval.
+
+Setting align to true will cause the timestamp to be truncated down to the nearest even integral of the reporting interval.
+
+For example, if the interval is 30 seconds, tiemstamps will be aligned on :00 and :30 for every reporting interval.
+
+This also maps to a similar option in Telegraf.
+
 Note
 ----
 
@@ -12,15 +22,18 @@ Usage
 -----
 
 ```go
-import "github.com/vrischmann/go-metrics-influxdb"
+import "github.com/jregovic/go-metrics-influxdb"
 
-go influxdb.InfluxDB(
-    metrics.DefaultRegistry, // metrics registry
-    time.Second * 10,        // interval
-    "http://localhost:8086", // the InfluxDB url
-    "mydb",                  // your InfluxDB database
-    "myuser",                // your InfluxDB user
-    "mypassword",            // your InfluxDB password
+go influxdb.InfluxDBWithTags(
+    metrics.DefaultRegistry,    // metrics registry
+    time.Second * 10,           // interval
+    metricsHost,                // the InfluxDB url
+    database,                   // your InfluxDB database
+    measurement,                // your measurement
+    metricsuser,                // your InfluxDB user
+    metricspass,                // your InfluxDB password
+    tags,                       //your tag set as map[string]string
+    aligntimestamps             //align the timestamps
 )
 ```
 

--- a/influxdb.go
+++ b/influxdb.go
@@ -13,9 +13,11 @@ import (
 type reporter struct {
 	reg      metrics.Registry
 	interval time.Duration
-
+	align bool
 	url      uurl.URL
 	database string
+	
+	measurement string
 	username string
 	password string
 	tags     map[string]string
@@ -24,12 +26,12 @@ type reporter struct {
 }
 
 // InfluxDB starts a InfluxDB reporter which will post the metrics from the given registry at each d interval.
-func InfluxDB(r metrics.Registry, d time.Duration, url, database, username, password string) {
-	InfluxDBWithTags(r, d, url, database, username, password, nil)
+func InfluxDB(r metrics.Registry, d time.Duration, url, database, measurement, username, password string) {
+	InfluxDBWithTags(r, d, url, database, measurement,username, password, nil)
 }
 
 // InfluxDBWithTags starts a InfluxDB reporter which will post the metrics from the given registry at each d interval with the specified tags
-func InfluxDBWithTags(r metrics.Registry, d time.Duration, url, database, username, password string, tags map[string]string) {
+func InfluxDBWithTags(r metrics.Registry, d time.Duration, url, database, measurement,username, password string, tags map[string]string,align bool) {
 	u, err := uurl.Parse(url)
 	if err != nil {
 		log.Printf("unable to parse InfluxDB url %s. err=%v", url, err)
@@ -41,9 +43,11 @@ func InfluxDBWithTags(r metrics.Registry, d time.Duration, url, database, userna
 		interval: d,
 		url:      *u,
 		database: database,
+		measurement: measurement,
 		username: username,
 		password: password,
 		tags:     tags,
+		align: bool,
 	}
 	if err := rep.makeClient(); err != nil {
 		log.Printf("unable to make InfluxDB client. err=%v", err)
@@ -89,47 +93,47 @@ func (r *reporter) run() {
 func (r *reporter) send() error {
 	var pts []client.Point
 
+	now := time.Now()
+	if r.align {
+		now = now
+	}.Truncate(r.interval)
 	r.reg.Each(func(name string, i interface{}) {
-		now := time.Now()
-
+		
 		switch metric := i.(type) {
 		case metrics.Counter:
 			ms := metric.Snapshot()
 			pts = append(pts, client.Point{
-				Measurement: fmt.Sprintf("%s.count", name),
+				Measurement: r.measurement,
 				Tags:        r.tags,
 				Fields: map[string]interface{}{
-					"value": ms.Count(),
+					fmt.Sprintf("%s.count", name): ms.Count(),
 				},
 				Time: now,
 			})
 		case metrics.Gauge:
 			ms := metric.Snapshot()
 			pts = append(pts, client.Point{
-				Measurement: fmt.Sprintf("%s.gauge", name),
+				Measurement: r.measurement,
 				Tags:        r.tags,
 				Fields: map[string]interface{}{
-					"value": ms.Value(),
+					fmt.Sprintf("%s.gauge", name): ms.Value(),
 				},
 				Time: now,
 			})
 		case metrics.GaugeFloat64:
 			ms := metric.Snapshot()
 			pts = append(pts, client.Point{
-				Measurement: fmt.Sprintf("%s.gauge", name),
+				Measurement: r.measurement,
 				Tags:        r.tags,
 				Fields: map[string]interface{}{
-					"value": ms.Value(),
+					fmt.Sprintf("%s.gauge", name): ms.Value(),
 				},
 				Time: now,
 			})
 		case metrics.Histogram:
 			ms := metric.Snapshot()
 			ps := ms.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999, 0.9999})
-			pts = append(pts, client.Point{
-				Measurement: fmt.Sprintf("%s.histogram", name),
-				Tags:        r.tags,
-				Fields: map[string]interface{}{
+			fields := map[string]interface{}{
 					"count":    ms.Count(),
 					"max":      ms.Max(),
 					"mean":     ms.Mean(),
@@ -142,30 +146,46 @@ func (r *reporter) send() error {
 					"p99":      ps[3],
 					"p999":     ps[4],
 					"p9999":    ps[5],
-				},
-				Time: now,
-			})
+				}
+			for k,v := range fields {
+				these_tags := r.tags
+				these_tags["bucket"] = k
+				pts = append(pts, client.Point{
+					Measurement: r.measurement,
+					Tags:        these_tags,
+					Fields: map[string]interface{}{
+						fmt.Sprintf("%s.histogram", name) : v,
+					},
+					Time: now,
+				})
+
+			}
 		case metrics.Meter:
 			ms := metric.Snapshot()
-			pts = append(pts, client.Point{
-				Measurement: fmt.Sprintf("%s.meter", name),
-				Tags:        r.tags,
-				Fields: map[string]interface{}{
+			fields := map[string]interface{}{
 					"count": ms.Count(),
 					"m1":    ms.Rate1(),
 					"m5":    ms.Rate5(),
 					"m15":   ms.Rate15(),
 					"mean":  ms.RateMean(),
-				},
-				Time: now,
-			})
+				}
+			for k,v := range fields {
+				these_tags := r.tags
+				these_tags["bucket"] = k
+				pts = append(pts, client.Point{
+					Measurement: r.measurement,
+					Tags:        these_tags,
+					Fields: map[string]interface{}{
+						fmt.Sprintf("%s.meter", name) : v,
+					},
+					Time: now,
+				})
+			}
+			
 		case metrics.Timer:
 			ms := metric.Snapshot()
 			ps := ms.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999, 0.9999})
-			pts = append(pts, client.Point{
-				Measurement: fmt.Sprintf("%s.timer", name),
-				Tags:        r.tags,
-				Fields: map[string]interface{}{
+			fields := map[string]interface{}{
 					"count":    ms.Count(),
 					"max":      ms.Max(),
 					"mean":     ms.Mean(),
@@ -182,9 +202,24 @@ func (r *reporter) send() error {
 					"m5":       ms.Rate5(),
 					"m15":      ms.Rate15(),
 					"meanrate": ms.RateMean(),
-				},
-				Time: now,
-			})
+			}
+			for k,v := range fields {
+				these_tags := r.tags
+				these_tags["bucket"] = k
+				data, ok := v.(float64)
+				if !ok {
+
+					data = float64(v.(int64))
+				}
+				pts = append(pts, client.Point{
+					Measurement: r.measurement,
+					Tags:        these_tags,
+					Fields: map[string]interface{}{
+						fmt.Sprintf("%s.timer", name) : data,
+					},
+					Time: now,
+				})
+			}
 		}
 	})
 

--- a/influxdb.go
+++ b/influxdb.go
@@ -91,9 +91,9 @@ func (r *reporter) run() {
 func (r *reporter) send() error {
 	var pts []client.Point
 
+	now := time.Now().Truncate(r.interval)
 	r.reg.Each(func(name string, i interface{}) {
-		now := time.Now()
-
+		
 		switch metric := i.(type) {
 		case metrics.Counter:
 			ms := metric.Snapshot()

--- a/influxdb.go
+++ b/influxdb.go
@@ -26,8 +26,8 @@ type reporter struct {
 }
 
 // InfluxDB starts a InfluxDB reporter which will post the metrics from the given registry at each d interval.
-func InfluxDB(r metrics.Registry, d time.Duration, url, database, measurement, username, password string) {
-	InfluxDBWithTags(r, d, url, database, measurement,username, password, nil)
+func InfluxDB(r metrics.Registry, d time.Duration, url, database, measurement, username, password string, align bool) {
+	InfluxDBWithTags(r, d, url, database, measurement,username, password, nil, align)
 }
 
 // InfluxDBWithTags starts a InfluxDB reporter which will post the metrics from the given registry at each d interval with the specified tags

--- a/influxdb.go
+++ b/influxdb.go
@@ -47,7 +47,7 @@ func InfluxDBWithTags(r metrics.Registry, d time.Duration, url, database, measur
 		username: username,
 		password: password,
 		tags:     tags,
-		align: bool,
+		align: align,
 	}
 	if err := rep.makeClient(); err != nil {
 		log.Printf("unable to make InfluxDB client. err=%v", err)


### PR DESCRIPTION
This commit does 3 things:

- Add a measurement to the output to better align with the InfluxDB idiom.
  This change creates a new measurement and makes sets the field name to value of the metric name, 
  This also aligns the configuration of histograms with the behavior of telegraf, where there is a bucket tag rather than an individual metric.

  https://github.com/influxdata/telegraf/tree/master/plugins/aggregators/histogram

- Align all the points to the same time when metrics are sent
  The previous behavior was to generate a unique time for each metric in a batch. This change generates the same timestamp for all metrics each time send() is called.

- Add a boolean to align time at the beginning of the interval, so a 10s interval would evenly align the time stamp at 00,10,20, etc. seconds